### PR TITLE
fix: page creates an in-and-out 'scrolling' behavior on wide screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
           min-width: 100px;
           min-height: 100px;
           background: #6f6f6f;
+          overflow-y: hidden;
         "
       >
         <svg


### PR DESCRIPTION
Problem:
On  a wide screen, the camera page seems to have an auto scroll in and out

Cause:
Problem was caused by the loading image animation causing an overflow of the page

Solution:
Set overflow to hidden to avoid the scroll