### PR TITLE
fix: alert users when errors are caught on startCapturing

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -46,8 +46,8 @@ async function startCapturing(mode) {
     scanModeContainer.style.display = "flex";
   } catch (ex) {
     let errMsg = ex.message || ex;
-    console.error(`An error occured: ${errMsg}`);
-    alert(`An error occured: ${errMsg}`);
+    console.error(`An error occurred: ${errMsg}`);
+    alert(`An error occurred: ${errMsg}`);
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -3,11 +3,10 @@ import { judgeCurResolution, shouldShowScanModeContainer, showNotification } fro
 import { checkOrientation, getVisibleRegionOfVideo } from "./util.js";
 
 function startCapturing(mode) {
-  try {
-    (async () => {
-      homePage.style.display = "none";
-      scannerContainer.style.display = "block";
-
+  (async () => {
+    homePage.style.display = "none";
+    scannerContainer.style.display = "block";
+    try {
       // Open the camera after the model and .wasm files have loaded
       pInit = pInit || (await init);
       await pDataLoad.promise;
@@ -45,12 +44,12 @@ function startCapturing(mode) {
 
       currentMode = mode;
       scanModeContainer.style.display = "flex";
-    })();
-  } catch (ex) {
-    let errMsg = ex.message || ex;
-    console.error(errMsg);
-    alert(errMsg);
-  }
+    } catch (ex) {
+      let errMsg = ex.message || ex;
+      console.error(errMsg);
+      alert(errMsg);
+    }
+  })();
 }
 
 SCAN_MODES.forEach((mode) =>

--- a/js/index.js
+++ b/js/index.js
@@ -2,54 +2,53 @@ import { init, pDataLoad } from "./init.js";
 import { judgeCurResolution, shouldShowScanModeContainer, showNotification } from "./util.js";
 import { checkOrientation, getVisibleRegionOfVideo } from "./util.js";
 
-function startCapturing(mode) {
-  (async () => {
+async function startCapturing(mode) {
+  try {
     homePage.style.display = "none";
     scannerContainer.style.display = "block";
-    try {
-      // Open the camera after the model and .wasm files have loaded
-      pInit = pInit || (await init);
-      await pDataLoad.promise;
 
-      // Starts streaming the video
-      if (cameraEnhancer.isOpen()) {
-        await cvRouter.stopCapturing();
-        await cameraView.clearAllInnerDrawingItems();
-      } else {
-        await cameraEnhancer.open();
-      }
+    // Open the camera after the model and .wasm files have loaded
+    pInit = pInit || (await init);
+    await pDataLoad.promise;
 
-      // Highlight the selected camera in the camera list container
-      const currentCamera = cameraEnhancer.getSelectedCamera();
-      const currentResolution = judgeCurResolution(cameraEnhancer.getResolution());
-      cameraListContainer.childNodes.forEach((child) => {
-        if (currentCamera.deviceId === child.deviceId && currentResolution === child.resolution) {
-          child.className = "camera-item camera-selected";
-        }
-      });
-      cameraEnhancer.setScanRegion(region());
-      cameraView.setScanRegionMaskVisible(false);
-
-      await cvRouter.startCapturing(SCAN_TEMPLATES[mode]);
-
-      // Show MRZ guide frame
-      mrzGuideFrame.style.display = "inline-block";
-
-      // Update button styles to show selected scan mode
-      document.querySelectorAll(".scan-option-btn").forEach((button) => {
-        button.classList.remove("selected");
-      });
-      document.querySelector(`#scan-${mode}-btn`).classList.add("selected");
-      showNotification(`Scan mode switched successfully`, "banner-success");
-
-      currentMode = mode;
-      scanModeContainer.style.display = "flex";
-    } catch (ex) {
-      let errMsg = ex.message || ex;
-      console.error(errMsg);
-      alert(errMsg);
+    // Starts streaming the video
+    if (cameraEnhancer.isOpen()) {
+      await cvRouter.stopCapturing();
+      await cameraView.clearAllInnerDrawingItems();
+    } else {
+      await cameraEnhancer.open();
     }
-  })();
+
+    // Highlight the selected camera in the camera list container
+    const currentCamera = cameraEnhancer.getSelectedCamera();
+    const currentResolution = judgeCurResolution(cameraEnhancer.getResolution());
+    cameraListContainer.childNodes.forEach((child) => {
+      if (currentCamera.deviceId === child.deviceId && currentResolution === child.resolution) {
+        child.className = "camera-item camera-selected";
+      }
+    });
+    cameraEnhancer.setScanRegion(region());
+    cameraView.setScanRegionMaskVisible(false);
+
+    await cvRouter.startCapturing(SCAN_TEMPLATES[mode]);
+
+    // Show MRZ guide frame
+    mrzGuideFrame.style.display = "inline-block";
+
+    // Update button styles to show selected scan mode
+    document.querySelectorAll(".scan-option-btn").forEach((button) => {
+      button.classList.remove("selected");
+    });
+    document.querySelector(`#scan-${mode}-btn`).classList.add("selected");
+    showNotification(`Scan mode switched successfully`, "banner-success");
+
+    currentMode = mode;
+    scanModeContainer.style.display = "flex";
+  } catch (ex) {
+    let errMsg = ex.message || ex;
+    console.error(errMsg);
+    alert(errMsg);
+  }
 }
 
 SCAN_MODES.forEach((mode) =>

--- a/js/index.js
+++ b/js/index.js
@@ -46,8 +46,8 @@ async function startCapturing(mode) {
     scanModeContainer.style.display = "flex";
   } catch (ex) {
     let errMsg = ex.message || ex;
-    console.error(errMsg);
-    alert(errMsg);
+    console.error(`An error occured: ${errMsg}`);
+    alert(`An error occured: ${errMsg}`);
   }
 }
 


### PR DESCRIPTION
Problem: Users are not prompted an alert when there's an error on startCapturing.

Cause: Try and Catch block was not handling exceptions/errors in the function.

Solution: Removed the redundant Immediately Invoked Function Expression (IIFE) and try catch will handle the errors.

To reproduce error
1. https://demo.dynamsoft.com/solutions/mrz-scanner/index.html
2. Open link above on edge and start capturing
3. Open link above on Chrome
4. See that there's no alert when the camera fails to start as the "Device is in use"